### PR TITLE
Update to PostCSS 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0 - 2016-05-10
+
+- Added: compatibility with postcss v6.x
+
 # 2.0.1 - 2016-11-28
 
 - Bump `color` dependency version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-color-rebeccapurple",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "PostCSS plugin to transform W3C CSS rebeccapurple color to more compatible CSS (rgb())",
   "keywords": [
     "css",
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "color": "^0.11.4",
-    "postcss": "^5.0.4"
+    "postcss": "^6.0.1"
   },
   "devDependencies": {
     "jscs": "^1.6.2",


### PR DESCRIPTION
This PR only updates PostCSS to version 6.

To update to PostCSS and improve the plugin, see https://github.com/postcss/postcss-color-rebeccapurple/pull/9