### PR TITLE
Use PostCSS 6 and improve accuracy of the plugin

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -121,10 +121,5 @@
   "requireCapitalizedConstructors": true,
   "safeContextKeyword": "that",
   "requireDotNotation": true,
-  "validateJSDoc": {
-    "checkParamNames": true,
-    "checkRedundantParams": true,
-    "requireParamTypes": true
-  },
   "requireSpaceAfterLineComment": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0 - 2016-05-10
+
+- Added: compatibility with postcss v6.x
+
 # 2.0.1 - 2016-11-28
 
 - Bump `color` dependency version

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 var postcss = require("postcss")
-var color = require("color")("rebeccapurple").rgbString()
+var color = "#639"
 
 /**
  * PostCSS plugin to convert colors

--- a/index.js
+++ b/index.js
@@ -1,25 +1,23 @@
 /**
  * Module dependencies.
  */
-var postcss = require("postcss")
-var valueParser = require("postcss-value-parser")
-var color = "#639"
+const postcss = require("postcss")
+const valueParser = require("postcss-value-parser")
+const color = "#639"
 
 /**
  * PostCSS plugin to convert colors
  */
-module.exports = postcss.plugin("postcss-color-rebeccapurple", function() {
-  return function(style) {
-    style.walkDecls(function(decl) {
-      var value = decl.value;
+module.exports = postcss.plugin("postcss-color-rebeccapurple", () => (style) => {
+  style.walkDecls((decl) => {
+    const value = decl.value;
 
-      if (value && value.indexOf("rebeccapurple") !== -1) {
-        decl.value = valueParser(value).walk(function(node) {
-          if (node.type === "word" && node.value === "rebeccapurple") {
-            node.value = color
-          }
-        }).toString()
-      }
-    })
-  }
+    if (value && value.indexOf("rebeccapurple") !== -1) {
+      decl.value = valueParser(value).walk((node) => {
+        if (node.type === "word" && node.value === "rebeccapurple") {
+          node.value = color
+        }
+      }).toString()
+    }
+  })
 })

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 var postcss = require("postcss")
+var valueParser = require("postcss-value-parser")
 var color = "#639"
 
 /**
@@ -13,7 +14,11 @@ module.exports = postcss.plugin("postcss-color-rebeccapurple", function() {
       var value = decl.value;
 
       if (value && value.indexOf("rebeccapurple") !== -1) {
-        decl.value = value.replace(/(rebeccapurple)\b/gi, color)
+        decl.value = valueParser(value).walk(function(node) {
+          if (node.type === "word" && node.value === "rebeccapurple") {
+            node.value = color
+          }
+        }).toString()
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-color-rebeccapurple",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "PostCSS plugin to transform W3C CSS rebeccapurple color to more compatible CSS (rgb())",
   "keywords": [
     "css",
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "color": "^0.11.4",
-    "postcss": "^5.0.4"
+    "postcss": "^6.0.1"
   },
   "devDependencies": {
     "jscs": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "postcss": "^6.0.1"
   },
   "devDependencies": {
-    "jscs": "^1.6.2",
-    "jshint": "^2.5.6",
+    "jscs": "^3.0.7",
+    "jshint": "^2.9.4",
     "npmpub": "^3.1.0",
-    "tape": "^4.0.0"
+    "tape": "^4.6.3"
   },
   "scripts": {
     "lint": "npm run jscs && npm run jshint",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "index.js"
   ],
   "dependencies": {
-    "postcss": "^6.0.1"
+    "postcss": "^6.0.1",
+    "postcss-value-parser": "^3.3.0"
   },
   "devDependencies": {
     "jscs": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "index.js"
   ],
   "dependencies": {
-    "color": "^0.11.4",
     "postcss": "^6.0.1"
   },
   "devDependencies": {

--- a/test/fixtures/rebeccapurple.css
+++ b/test/fixtures/rebeccapurple.css
@@ -2,3 +2,7 @@ body {
   color: rebeccapurple;
   background: linear-gradient(rebeccapurple, blue 50%, rebeccapurple);
 }
+
+a {
+  color: oldrebeccapurple;
+}

--- a/test/fixtures/rebeccapurple.expected.css
+++ b/test/fixtures/rebeccapurple.expected.css
@@ -2,3 +2,7 @@ body {
   color: #639;
   background: linear-gradient(#639, blue 50%, #639);
 }
+
+a {
+  color: oldrebeccapurple;
+}

--- a/test/fixtures/rebeccapurple.expected.css
+++ b/test/fixtures/rebeccapurple.expected.css
@@ -1,4 +1,4 @@
 body {
-  color: rgb(102, 51, 153);
-  background: linear-gradient(rgb(102, 51, 153), blue 50%, rgb(102, 51, 153));
+  color: #639;
+  background: linear-gradient(#639, blue 50%, #639);
 }


### PR DESCRIPTION
This PR updates PostCSS to version 6 and includes some other improvements:

- Drops the `color` dependency for a simple #639 replacement
- Updates JSCS and drops invalid JSCS options
- Accurately parses the `rebeccapurple` word using `postcss-value-parser` (includes failing test with current syntax otherwise)
- Uses Node v4 syntax (arrow functions, const)