### PR TITLE
3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 3.0.0 - 2016-05-10
+# 3.1.0 - 2018-05-01
+
+- Improve `rebeccapurple` pre-parse word detection
+- Switched from `postcss-value-parser` to `postcss-values-parser`
+- Bump `postcss` from `^6.0.1` to `^6.0.22`
+
+# 3.0.0 - 2017-05-10
 
 - Added: compatibility with postcss v6.x
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const postcss = require("postcss")
 const valueParser = require("postcss-value-parser")
 const color = "#639"
+const regexp = /(^|[^\w-])rebeccapurple([^\w-]|$)/
 
 /**
  * PostCSS plugin to convert colors
@@ -12,7 +13,7 @@ module.exports = postcss.plugin("postcss-color-rebeccapurple", () => (style) => 
   style.walkDecls((decl) => {
     const value = decl.value;
 
-    if (value && value.indexOf("rebeccapurple") !== -1) {
+    if (value && regexp.test(value)) {
       decl.value = valueParser(value).walk((node) => {
         if (node.type === "word" && node.value === "rebeccapurple") {
           node.value = color

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 const postcss = require("postcss")
-const valueParser = require("postcss-value-parser")
+const valueParser = require("postcss-values-parser")
 const color = "#639"
 const regexp = /(^|[^\w-])rebeccapurple([^\w-]|$)/
 
@@ -14,11 +14,15 @@ module.exports = postcss.plugin("postcss-color-rebeccapurple", () => (style) => 
     const value = decl.value;
 
     if (value && regexp.test(value)) {
-      decl.value = valueParser(value).walk((node) => {
+      const ast = valueParser(value).parse()
+
+      ast.walk(node => {
         if (node.type === "word" && node.value === "rebeccapurple") {
           node.value = color
         }
-      }).toString()
+      })
+
+      decl.value = ast.toString()
     }
   })
 })

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "postcss": "^6.0.22",
-    "postcss-value-parser": "^3.3.0"
+    "postcss-values-parser": "^1.5.0"
   },
   "devDependencies": {
     "jscs": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "index.js"
   ],
   "dependencies": {
-    "postcss": "^6.0.1",
+    "postcss": "^6.0.22",
     "postcss-value-parser": "^3.3.0"
   },
   "devDependencies": {
     "jscs": "^3.0.7",
-    "jshint": "^2.9.4",
+    "jshint": "^2.9.5",
     "npmpub": "^3.1.0",
-    "tape": "^4.6.3"
+    "tape": "^4.9.0"
   },
   "scripts": {
     "lint": "npm run jscs && npm run jshint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-color-rebeccapurple",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "PostCSS plugin to transform W3C CSS rebeccapurple color to more compatible CSS (rgb())",
   "keywords": [
     "css",

--- a/test/index.js
+++ b/test/index.js
@@ -14,11 +14,10 @@ function compareFixtures(t, name, msg, opts, postcssOpts) {
   opts = opts || {}
   var actual = postcss().use(plugin(opts)).process(read(postcssOpts.from), postcssOpts).css
   var expected = read(filename("fixtures/" + name + ".expected"))
-  fs.writeFile(filename("fixtures/" + name + ".actual"), actual)
+  fs.writeFile(filename("fixtures/" + name + ".actual"), actual, t.end)
   t.equal(actual, expected, msg)
 }
 
 test("rebeccapurple", function(t) {
   compareFixtures(t, "rebeccapurple", "should transform rebeccapurple")
-  t.end()
 })


### PR DESCRIPTION
- Improve `rebeccapurple` pre-parse word detection
- Switch from `postcss-value-parser` to `postcss-values-parser`
- Bump `postcss` from `^6.0.1` to `^6.0.22`

---

Details: pre-parse word detection:
Use the same regexp technique used for pre-parse detection as postcss-custom-properties https://github.com/postcss/postcss-custom-properties/blob/7.0.0/index.js#L6

---

Details: Switch from `postcss-value-parser` to `postcss-values-parser`
- parsing improvements https://github.com/shellscape/postcss-values-parser#postcss-values-parser-vs-postcss-value-parser
- postcss-values-parser is used by prettier https://github.com/prettier/prettier/blob/1.12.1/package.json#L51
- postcss-value-parser hasn’t been updated in 2 years