### PR TITLE
Switching to postcss-value-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "postcss-values-parser": "^6"
+    "postcss-value-parser": "^4.2.0"
   },
   "peerDependencies": {
     "postcss": "^8.3"

--- a/src/onCSSDeclaration.js
+++ b/src/onCSSDeclaration.js
@@ -1,4 +1,4 @@
-import { parse } from 'postcss-values-parser'
+import valuesParser from 'postcss-value-parser'
 import onCSSIdentifier from './onCSSIdentifier'
 import options from './options'
 
@@ -7,9 +7,13 @@ const onCSSDeclaration = decl => {
 	const { value: originalValue } = decl
 
 	if (hasAnyRebeccapurple(originalValue)) {
-		const valueAST = parse(originalValue)
+		const valueAST = valuesParser(originalValue)
 
-		valueAST.walkType('word', onCSSIdentifier)
+		valueAST.walk(node => {
+			if (node.type === 'word') {
+				onCSSIdentifier(node);
+			}
+		});
 
 		const modifiedValue = String(valueAST)
 


### PR DESCRIPTION
This is a PR to swap `postcss-values-parser` to `postcss-value-parser` given this issue: https://github.com/csstools/postcss-preset-env/issues/228

We've identified that prototype modification leads to unexpected behavior whenever multiple versions are running. This can happen due to different versions or due to NPM not deduping.